### PR TITLE
Instrument torchsupport with logging framework that supports MLflow

### DIFF
--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -6,7 +6,7 @@ from torch.utils.data import Dataset
 from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 
-from torchsupport.training.vae import VAETraining
+from torchsupport.training.vae import VAETraining, LoggingTypes, LoggerTypes
 
 def normalize(image):
   return (image - image.min()) / (image.max() - image.min())
@@ -59,15 +59,18 @@ class Decoder(nn.Module):
   def forward(self, sample):
     return self.decoder(sample).view(-1, 1, 28, 28)
 
+
 class MNISTVAETraining(VAETraining):
   def run_networks(self, data, *args):
     mean, logvar, reconstruction, data = super().run_networks(data, *args)
-    self.writer.add_image("target", normalize(data[0]), self.step_id)
-    self.writer.add_image("reconstruction", normalize(reconstruction[0].sigmoid()), self.step_id)
+    # self.writer.add_image("target", normalize(data[0]), self.step_id)
+    self.logger.log(LoggingTypes.IMAGE, "target", normalize(data[0]), self.step_id)
+    # self.writer.add_image("reconstruction", normalize(reconstruction[0].sigmoid()), self.step_id)
+    self.logger.log(LoggingTypes.IMAGE, "reconstruction", normalize(reconstruction[0].sigmoid()), self.step_id)
     return mean, logvar, reconstruction, data
 
 if __name__ == "__main__":
-  mnist = MNIST("examples/", download=False, transform=ToTensor())
+  mnist = MNIST("examples/", download=True, transform=ToTensor())
   data = VAEDataset(mnist)
 
   encoder = Encoder(z=32)
@@ -79,6 +82,7 @@ if __name__ == "__main__":
     device="cpu",
     batch_size=64,
     max_epochs=1000,
+    logger_type=LoggerTypes.TENSORBOARD,
     verbose=True
   )
 

--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -70,7 +70,7 @@ class MNISTVAETraining(VAETraining):
     return mean, logvar, reconstruction, data
 
 if __name__ == "__main__":
-  mnist = MNIST("examples/", download=True, transform=ToTensor())
+  mnist = MNIST("examples/", download=False, transform=ToTensor())
   data = VAEDataset(mnist)
 
   encoder = Encoder(z=32)
@@ -82,7 +82,6 @@ if __name__ == "__main__":
     device="cpu",
     batch_size=64,
     max_epochs=1000,
-    logger_type=LoggerTypes.TENSORBOARD,
     verbose=True
   )
 

--- a/torchsupport/training/vae.py
+++ b/torchsupport/training/vae.py
@@ -137,7 +137,7 @@ class AbstractVAETraining(Training):
 
     self.current_losses = {}
     self.network_name = network_name
-    # self.writer = SummaryWriter(network_name)
+    self.writer = SummaryWriter(network_name)
     if logger_type == LoggerTypes.TENSORBOARD:
       self.logger = TensorboardLogger(network_name)
     elif logger_type == LoggerTypes.MLFLOW:


### PR DESCRIPTION
**Context**
There's a desire to support MLflow logging in torchsupport's tooling to support the SCGPM COVID-19 effort. The way that torchsupport is currently structured involves a hardcoded support for a Tensorboard SummaryWriter. However, as written, this means significant code change would be required to support MLflow and it would be duplicative with what already exists for Tensorboard. 

**Proposal for Review**
I propose that the AbstractVAETraining class, instead of having a Tensorboard writer, has a "Logger". This logger supports a generalized "log" API, which is implemented by backends that implement the Logger interface. For example, there would be a TensorboardLogger interface that implements logging Tensorboard events. In this framework, it's easy to conceptualize an MLflowLogger, which would log to MLflow as well with the same API. This way, if you're implementing some kind of custom training workflow, you have a consistent logging interface to call that is flexible in terms of what service you log to.

There's 2 open questions here: 

1. **Where should such a logging system sit code-wise?** Should it be in the Training abstract class? For now, it's been put in AbstractVAETraining, since that's where the writer was defined.
2. **Should writer be removed?** For now, it is not, since other training workflows may have overwritten functions like step/train/checkpoint and assumed the existence of self.writer.

TODOs:
1. Remove self.writer calls in the pre-defined VAE workflows. They're left in so you all have context for where changes were made.
2. Add a way to include a tracking URI for MLflow - this is possible to pass in as an environment variable, but ideally, we'd like it to be settable as a param.
3. Saving model parameters - right now, the code seems to be packaging up parameters from the optimizer and models through some mechanism. It would be good to find a way to log these to MLflow as well.